### PR TITLE
Improve screenshot saving and browser download support

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -40,7 +40,7 @@ window/windows_native_icon=""
 
 folder_colors={
 "res://Assets/": "teal",
-"res://Autoloads/": "green",
+"res://Autoloads/": "pink",
 "res://Resources/": "yellow",
 "res://Scenes/": "orange",
 "res://Scripts/": "red"


### PR DESCRIPTION
Added option to trigger browser download after saving screenshots on web platforms. Improved directory creation logic, ensured frame completion before capture, and updated status messages for platform-specific feedback. Also changed folder color for Autoloads in project settings.